### PR TITLE
Add sample optimized for minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,199 @@
 # ocm-kubevirt-samples
+
+This repo contains sample kubevirt resources for deployment in
+Kubernetes or OpenShift clusters.
+
+
+## Using in OpenShift
+
+Use ACM console to deploy the VM, enable DR or delete the
+VM.
+
+### Deploying the VM
+
+1. Create new application using:
+   - repo: this repo URL
+   - branch: main
+   - path: one of the `vm-*-odr-*` directories
+
+1. To enable DR assign DR Policy
+
+### Testing DR
+
+Use ACM console to perform `failover` or `relocate` actions.
+
+### Deleting the VM
+
+Use ACM console to delete the application.
+
+
+## Using in Kubernetes
+
+In Kubernetes you need to deploy the VM and DR resources using the
+command line tools or API.
+
+### Adding your SSH key
+
+If you want to inject your SSH key into the VM, you need to replace
+the included SSH public key with your own public key.
+
+1. Fork this repo in github
+1. Replace the contents of the `vm-standalone-pvc-k8s/test_rsa.pub` with
+   *your* public key (e.g. `~/.ssh/id_rsa.pub`)
+1. Update `channel/channel.yaml` to point to *your* repository
+   (e.g. https://github.com/my-github-user/ocm-kubevirt-samples.git)
+1. If you are not using the `main` branch update
+   `subscription/subscription.yaml` to point to the right branch.
+
+### Deploying the channel
+
+Deploy the channel to introduce this repo to *OCM*:
+
+```sh
+kubectl apply -k channel --context hub
+```
+
+### Deploying the VM subscription
+
+To start the VM deploy the subscription:
+
+```sh
+kubectl apply -k subscription --context hub
+```
+
+The subscription starts the VM `vm-standalone-pvc-k8s` on one of the
+clusters in the default clusterset.
+
+The subscription is optimized for *Ramen* minikube based test
+environment. To use in another setup you may need to modify the
+resources.
+
+### Enabling DR for the VM
+
+To allow *Ramen* to protect the VM, you need to disable *OCM*
+scheduling by adding an annotation to the VM placement:
+
+```sh
+kubectl annotate placement kubevirt-placement \
+    cluster.open-cluster-management.io/experimental-scheduling-disable=true \
+    --namespace kubevirt-sample \
+    --context hub
+```
+
+Deploy the DR resources to enable DR:
+
+```sh
+kubectl apply -k dr --context hub
+```
+
+At this point *Ramen* controls the VM, and you can test DR
+actions.
+
+### Failing over to another cluster
+
+In case of disaster you can force the VM to run on the other cluster.
+The VM will start on the other cluster using the data from the last
+replication. Data since the last replication is lost.
+
+Patch the VM `DRPlacementControl` resource to set `action` and
+`failoverCluster`:
+
+```sh
+kubectl patch drpc kubevirt-drpc \
+    --patch '{"spec": {"action": "Failover", "failoverCluster": "dr2"}}' \
+    --type merge \
+    --namespace kubevirt-sample \
+    --context hub
+```
+
+The VM will start on the failover cluster ("dr2"), and the instance
+running on the original cluster ("dr1") will be terminated.
+
+To wait until the operation is completed use:
+
+```sh
+kubectl wait drpc kubevirt-drpc \
+    --for condition=PeerReady \
+    --namespace kubevirt-sample \
+    --timeout 5m \
+    --context hub
+```
+
+### Relocating to another cluster
+
+To move the VM back to the original cluster after a disaster
+you can use the `Relocate` action. The VM will be terminated on
+the current cluster, and started on the other cluster. No data is lost
+during this operation.
+
+Patch the VM `DRPlacementControl` resource to set `action` and
+if needed, `preferredCluster`.
+
+```sh
+kubectl patch drpc kubevirt-drpc \
+    --patch '{"spec": {"action": "Relocate", "preferredCluster": "dr1"}}' \
+    --type merge \
+    --namespace kubevirt-sample \
+    --context hub
+```
+
+The VM will terminate on the current cluster and will start on the
+preferred cluster.
+
+To wait until the operation is completed, wait until the drpc phase is
+`Relocated`:
+
+```sh
+kubectl wait drpc kubevirt-drpc \
+    --for jsonpath='{.status.phase}=Relocated' \
+    --namespace kubevirt-sample \
+    --timeout 5m \
+    --context hub
+```
+
+Finally wait for the `PeerReady` condition:
+
+```sh
+kubectl wait drpc kubevirt-drpc \
+    --for condition=PeerReady \
+    --namespace kubevirt-sample \
+    --timeout 5m \
+    --context hub
+```
+
+### Disable DR for the VM
+
+Delete the `dr` resources to disable DR:
+
+```sh
+kubectl delete -k dr --context hub
+```
+
+Enable *OCM* scheduling again by deleting the placement annotation we
+added before:
+
+```sh
+kubectl annotate placement kubevirt-placement \
+    cluster.open-cluster-management.io/experimental-scheduling-disable- \
+    --namespace kubevirt-sample \
+    --context hub
+```
+
+At this point *OCM* controls the VM and the storage used for replicating
+the VM data on the DR clusters will be reclaimed.
+
+### Undeploying the VM
+
+Delete the subscription to stop and delete the VM:
+
+```sh
+kubectl delete -k subscription --context hub
+```
+
+### Delete the channel
+
+When done you can delete the channel:
+
+```sh
+kubectl delete -k channel --context hub
+```

--- a/channel/channel.yaml
+++ b/channel/channel.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: kubevirt-gitops
+spec:
+  type: GitHub
+  pathname: https://github.com/aglitke/ocm-kubevirt-samples.git

--- a/channel/kustomization.yaml
+++ b/channel/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+resources:
+- channel.yaml
+- namespace.yaml
+namespace: kubevirt-samples

--- a/channel/namespace.yaml
+++ b/channel/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-samples

--- a/dr/drpc.yaml
+++ b/dr/drpc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPlacementControl
+metadata:
+  name: kubevirt-drpc
+  labels:
+    app: kubevirt-sample
+spec:
+  preferredCluster: "dr1"
+  drPolicyRef:
+    name: dr-policy
+  placementRef:
+    kind: Placement
+    name: kubevirt-placement
+  pvcSelector:
+    matchLabels:
+      appname: vm-standalone-dv-odr-regional

--- a/dr/kustomization.yaml
+++ b/dr/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+- drpc.yaml
+namespace: kubevirt-sample
+commonLabels:
+  app: kubevirt-sample

--- a/subscription/binding.yaml
+++ b/subscription/binding.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: default
+spec:
+  clusterSet: default

--- a/subscription/kustomization.yaml
+++ b/subscription/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+resources:
+- namespace.yaml
+- binding.yaml
+- placement.yaml
+- subscription.yaml
+namespace: kubevirt-sample
+commonLabels:
+  app: kubevirt-sample

--- a/subscription/namespace.yaml
+++ b/subscription/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-sample

--- a/subscription/placement.yaml
+++ b/subscription/placement.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: kubevirt-placement
+spec:
+  clusterSets:
+  - default
+  numberOfClusters: 1

--- a/subscription/subscription.yaml
+++ b/subscription/subscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: vm-standalone-pvc-k8s
+  name: kubevirt-sub
+spec:
+    channel: kubevirt-samples/kubevirt-gitops
+    placement:
+      placementRef:
+        kind: Placement
+        name: kubevirt-placement

--- a/vm-standalone-pvc-k8s/README.md
+++ b/vm-standalone-pvc-k8s/README.md
@@ -1,0 +1,8 @@
+# VM for testing DR in ramen test environment
+
+This VM is optimized for *Ramen* minikube based test environment.
+
+*Ramen* test environment creates 3 *minikube* clusters (hub, dr1, dr2)
+on your laptop, including *OCM*, *Rook*, *Kubevirt*, *CDI*, and many
+other components required by *Ramen*. For more info see
+[User quick start](https://github.com/RamenDR/ramen/blob/main/docs/user-quick-start.md).

--- a/vm-standalone-pvc-k8s/kustomization.yaml
+++ b/vm-standalone-pvc-k8s/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+resources:
+- source.yaml
+- pvc.yaml
+- vm.yaml
+commonLabels:
+  appname: vm-standalone-dv-odr-regional
+secretGenerator:
+- name: my-public-key
+  files:
+  - test_rsa.pub
+generatorOptions:
+  disableNameSuffixHash: true

--- a/vm-standalone-pvc-k8s/pvc.yaml
+++ b/vm-standalone-pvc-k8s/pvc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sample-vm-pvc
+spec:
+  dataSourceRef:
+    apiGroup: cdi.kubevirt.io
+    kind: VolumeImportSource
+    name: cirros-source
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 128Mi
+  storageClassName: rook-ceph-block
+  volumeMode: Block

--- a/vm-standalone-pvc-k8s/source.yaml
+++ b/vm-standalone-pvc-k8s/source.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: VolumeImportSource
+metadata:
+  name: cirros-source
+spec:
+  source:
+    registry:
+      # Image customized for ramen testing.
+      # TODO: Consume from ramendr repo when available.
+      url: "docker://quay.io/nirsof/cirros:0.6.2-1"

--- a/vm-standalone-pvc-k8s/test_rsa.pub
+++ b/vm-standalone-pvc-k8s/test_rsa.pub
@@ -1,0 +1,1 @@
+replace this text with your public key contents

--- a/vm-standalone-pvc-k8s/vm.yaml
+++ b/vm-standalone-pvc-k8s/vm.yaml
@@ -1,0 +1,64 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: sample-vm
+spec:
+  running: true
+  template:
+    metadata:
+      annotations:
+        vm.kubevirt.io/flavor: small
+        vm.kubevirt.io/os: fedora
+        vm.kubevirt.io/workload: server
+      labels:
+        kubevirt.io/size: small
+    spec:
+      domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: rootdisk
+          - name: cloudinit
+            disk: {}
+          interfaces:
+          - macAddress: 02:69:36:00:00:00
+            bridge: {}
+            model: virtio
+            name: default
+          networkInterfaceMultiqueue: true
+          rng: {}
+        features:
+          acpi: {}
+        machine:
+          type: pc-q35-rhel8.6.0
+        resources:
+          requests:
+            # Match cirros-source memory requirements.
+            # See https://github.com/cirros-dev/cirros/issues/53
+            memory: 256Mi
+      evictionStrategy: LiveMigrate
+      networks:
+      - name: default
+        pod: {}
+      terminationGracePeriodSeconds: 180
+      accessCredentials:
+      - sshPublicKey:
+          source:
+            secret:
+              secretName: my-public-key
+          propagationMethod:
+            configDrive: {}
+      volumes:
+      - name: rootdisk
+        persistentVolumeClaim:
+          claimName: sample-vm-pvc
+      - name: cloudinit
+        cloudInitConfigDrive:
+          userData: |
+            #!/bin/sh
+            echo "Running user-data script"


### PR DESCRIPTION
Adding sample that can be installed on ramen minikube based test environment.

The new vm should probably use an overlay so we don't duplicate the vm and pvc.
I started with copying to simplify testing.

Tested with
https://github.com/RamenDR/ramen/pull/1096