### PR TITLE
Add section for setting up the testing environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,21 @@ Use ACM console to delete the application.
 ## Using in Kubernetes
 
 In Kubernetes you need to deploy the VM and DR resources using the
-command line tools or API.
+command line tools or API. In this example we use the ramen testing
+environment.
+
+### Setting up the testing environment
+
+*Ramen* test environment creates 3 *minikube* clusters (hub, dr1, dr2)
+on your laptop, including *OCM*, *Rook*, *Kubevirt*, *CDI*, and many
+other components required by *Ramen*.
+
+See the [User quick start guide](https://github.com/RamenDR/ramen/blob/main/docs/user-quick-start.md)
+for complete instructions.
+
+> [!IMPORTANT]
+> When starting the environment, use the `regional-dr-kubvirt.yaml`
+> configuration.
 
 ### Adding your SSH key
 

--- a/vm-standalone-pvc-k8s/README.md
+++ b/vm-standalone-pvc-k8s/README.md
@@ -1,8 +1,3 @@
 # VM for testing DR in ramen test environment
 
 This VM is optimized for *Ramen* minikube based test environment.
-
-*Ramen* test environment creates 3 *minikube* clusters (hub, dr1, dr2)
-on your laptop, including *OCM*, *Rook*, *Kubevirt*, *CDI*, and many
-other components required by *Ramen*. For more info see
-[User quick start](https://github.com/RamenDR/ramen/blob/main/docs/user-quick-start.md).


### PR DESCRIPTION
Moved the info in the vm-standalone-pvc-k8s to a better place and add the missing info about the `regional-dr-kubevirt.yaml` configuration.