### PR TITLE
Add PVC based VM for Metro DR OpenShift environment

### DIFF
--- a/odr-vm-pvc-metro/README.md
+++ b/odr-vm-pvc-metro/README.md
@@ -1,0 +1,1 @@
+# VM for testing in Metro DR OpenShift environment

--- a/odr-vm-pvc-metro/kustomization.yaml
+++ b/odr-vm-pvc-metro/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+resources:
+  - source.yaml
+  - pvc.yaml
+  - vm.yaml
+commonLabels:
+  appname: kubevirt
+secretGenerator:
+- name: my-public-key
+  files:
+  - test_rsa.pub
+generatorOptions:
+  disableNameSuffixHash: true

--- a/odr-vm-pvc-metro/pvc.yaml
+++ b/odr-vm-pvc-metro/pvc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sample-vm-pvc
+spec:
+  dataSourceRef:
+    apiGroup: cdi.kubevirt.io
+    kind: VolumeImportSource
+    name: cirros-source
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 128Mi
+  storageClassName: ocs-external-storagecluster-ceph-rbd
+  volumeMode: Block

--- a/odr-vm-pvc-metro/source.yaml
+++ b/odr-vm-pvc-metro/source.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: VolumeImportSource
+metadata:
+  name: cirros-source
+spec:
+  source:
+    registry:
+      # Image customized for ramen testing.
+      url: "docker://quay.io/nirsof/cirros:0.6.2-1"

--- a/odr-vm-pvc-metro/test_rsa.pub
+++ b/odr-vm-pvc-metro/test_rsa.pub
@@ -1,0 +1,1 @@
+replace this text with your public key contents

--- a/odr-vm-pvc-metro/vm.yaml
+++ b/odr-vm-pvc-metro/vm.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: sample-vm
+spec:
+  running: true
+  template:
+    metadata:
+      annotations:
+        vm.kubevirt.io/flavor: small
+        vm.kubevirt.io/os: fedora
+        vm.kubevirt.io/workload: server
+      labels:
+        kubevirt.io/size: small
+    spec:
+      domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+            - name: cloudinit
+              disk: {}
+          interfaces:
+            - name: default
+              masquerade: {}
+              model: virtio
+          networkInterfaceMultiqueue: true
+          rng: {}
+        features:
+          acpi: {}
+        machine:
+          type: pc-q35-rhel8.6.0
+        resources:
+          requests:
+            # Match cirros-source memory requirements.
+            # See https://github.com/cirros-dev/cirros/issues/53
+            memory: 256Mi
+      evictionStrategy: LiveMigrate
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 180
+      accessCredentials:
+        - sshPublicKey:
+            source:
+              secret:
+                secretName: my-public-key
+            propagationMethod:
+              configDrive: {}
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: sample-vm-pvc
+        - name: cloudinit
+          cloudInitConfigDrive:
+            userData: |
+              #!/bin/sh
+              echo "Running user-data script"


### PR DESCRIPTION
This is a copy of vm-standalone-pvc-k8s changing the storage class name to match OpenShift Metro DR environment.

Additionally some details are refined:
- Shorter and more uniform sample name
- Remove the macaddress from the yaml so we can create multiple vms from the same git repo
- Standard `masquerade` network (the k8s version is using `bridge` to workaround issue in minikube environment)
- Uniform and short appname=kubevirt label to make it easy to debug
- Improved yaml indentation to make the yamls easier to grok

Tested deploy, relocate, disable dr, undeploy on OpenShift MDR setup

We need to unify with other examples and remove duplication in the yamls, but this can be done later.